### PR TITLE
fix to add prefix of path at local

### DIFF
--- a/ridge.go
+++ b/ridge.go
@@ -197,10 +197,14 @@ func Run(address, prefix string, mux http.Handler) {
 		}
 	} else {
 		m := http.NewServeMux()
-		if !strings.HasSuffix(prefix, "/") {
-			prefix = prefix + "/"
+		switch {
+		case prefix == "/", prefix == "":
+			m.Handle("/", mux)
+		case !strings.HasSuffix(prefix, "/"):
+			m.Handle(prefix+"/", http.StripPrefix(prefix, mux))
+		default:
+			m.Handle(prefix, http.StripPrefix(strings.TrimSuffix(prefix, "/"), mux))
 		}
-		m.Handle(prefix, http.StripPrefix(prefix, mux))
 		log.Println("starting up with local httpd", address)
 		log.Fatal(http.ListenAndServe(address, m))
 	}


### PR DESCRIPTION
This pull request fix behavior that add prefix to path at local.

In following case:

```go
mux := http.NewServeMux()
mux.HandleFunc("/", handleRoot)
ridge.Run(":8080", "/api", mux)
```

A expected response is `handleRoot` when access to `http://localhost:8080/api/`. But this return `301` code at the base branch.

`ridge.Run()` use `https.StripPath`. This method strip path in handler. If strip `/api/` on prefix, `/api/hello` to `hello`. `http.ServeMux` redirect to additional slashes path if request path that look like trailing handler path.

In this pull request, `http.StripPath`'s argument is removed slash path.