### PR TITLE
Set default content type

### DIFF
--- a/request.go
+++ b/request.go
@@ -51,11 +51,15 @@ func NewRequest(event json.RawMessage) (*http.Request, error) {
 	switch r.Version {
 	case "2.0":
 		var rv2 RequestV2
-		json.Unmarshal(event, &rv2)
+		if err := json.Unmarshal(event, &rv2); err != nil {
+			return nil, err
+		}
 		return rv2.httpRequest()
 	case "1.0", "":
 		var rv1 RequestV1
-		json.Unmarshal(event, &rv1)
+		if err := json.Unmarshal(event, &rv1); err != nil {
+			return nil, err
+		}
 		return rv1.httpRequest()
 	default:
 		return nil, fmt.Errorf("Payload Version %s is not supported", r.Version)

--- a/request_v1_test.go
+++ b/request_v1_test.go
@@ -162,6 +162,9 @@ func TestResponseWriter(t *testing.T) {
 	if res.IsBase64Encoded != false {
 		t.Error("set isBase64Encoded = true, but this is text response")
 	}
+	if res.Headers["Content-Type"] != "text/plain" {
+		t.Error("invalid content-type")
+	}
 }
 
 func TestResponseWriter__Image(t *testing.T) {
@@ -187,5 +190,8 @@ func TestResponseWriter__Image(t *testing.T) {
 	}
 	if res.Body != expectedBody {
 		t.Errorf("base64 encoded body is not match: got=%s", res.Body)
+	}
+	if res.Headers["Content-Type"] != "image/png" {
+		t.Error("invalid content-type")
 	}
 }

--- a/request_v1_test.go
+++ b/request_v1_test.go
@@ -162,7 +162,7 @@ func TestResponseWriter(t *testing.T) {
 	if res.IsBase64Encoded != false {
 		t.Error("set isBase64Encoded = true, but this is text response")
 	}
-	if res.Headers["Content-Type"] != "text/plain" {
+	if res.Headers["Content-Type"] != "text/plain; charset=utf-8" {
 		t.Error("invalid content-type")
 	}
 }

--- a/ridge.go
+++ b/ridge.go
@@ -55,6 +55,9 @@ func (w *ResponseWriter) Response() Response {
 	body := w.String()
 	isBase64Encoded := false
 
+	if t := w.header.Get("Content-Type"); t == "" {
+		w.header.Set("Content-Type", "text/plain")
+	}
 	h := make(map[string]string, len(w.header))
 	for key := range w.header {
 		v := w.header.Get(key)

--- a/ridge.go
+++ b/ridge.go
@@ -17,6 +17,9 @@ import (
 // TextMimeTypes is a list of identified as text.
 var TextMimeTypes = []string{"image/svg+xml", "application/json", "application/xml"}
 
+// DefaultContentType is a default content-type when missing in response.
+var DefaultContentType = "text/plain"
+
 // Response represents a response for API Gateway proxy integration.
 type Response struct {
 	StatusCode        int               `json:"statusCode"`
@@ -56,7 +59,7 @@ func (w *ResponseWriter) Response() Response {
 	isBase64Encoded := false
 
 	if t := w.header.Get("Content-Type"); t == "" {
-		w.header.Set("Content-Type", "text/plain")
+		w.header.Set("Content-Type", DefaultContentType)
 	}
 	h := make(map[string]string, len(w.header))
 	for key := range w.header {

--- a/ridge.go
+++ b/ridge.go
@@ -18,7 +18,7 @@ import (
 var TextMimeTypes = []string{"image/svg+xml", "application/json", "application/xml"}
 
 // DefaultContentType is a default content-type when missing in response.
-var DefaultContentType = "text/plain"
+var DefaultContentType = "text/plain; charset=utf-8"
 
 // Response represents a response for API Gateway proxy integration.
 type Response struct {


### PR DESCRIPTION
When Content-Type is missing in response, ALB set it to "application/octet-stream".
But API Gateway sets it to "text/plain; charset=utf-8".

Ridge becomes to enforce it to "text/plain; charset=utf-8" by default.