### PR TITLE
Drop apex support.

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -5,23 +5,22 @@ jobs:
     strategy:
       matrix:
         go:
-          - 1.13
           - 1.14
+          - 1.15
     name: Build
     runs-on: ubuntu-latest
     steps:
+      - name: Set up Go
+        uses: actions/setup-go@v1
+        with:
+          go-version: ${{ matrix.go }}
+        id: go
 
-    - name: Set up Go
-      uses: actions/setup-go@v1
-      with:
-        go-version: ${{ matrix.go }}
-      id: go
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v1
 
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v1
-
-    - name: Build & Test
-      env:
-        GO111MODULE: on
-      run: |
-        go test -v .
+      - name: Build & Test
+        env:
+          GO111MODULE: on
+        run: |
+          go test -v .

--- a/README.md
+++ b/README.md
@@ -49,9 +49,8 @@ func handleRoot(w http.ResponseWriter, r *http.Request) {
 
 `ridge.Run(address, prefix, handler)` works as below.
 
-- If a process is running on Lambda (`AWS_EXECUTION_ENV` environment variable defined),
-  - Call apex.HandleFunc() when runtime is nodejs*
-  - Call lambda.Start() when runtime is go1.x
+- If a process is running on Lambda (`AWS_EXECUTION_ENV` or `AWS_LAMBDA_RUNTIME_API` environment variable defined),
+  - Call lambda.Start()
 - Otherwise start a net/http server using prefix and address.
 
 ## LICENSE

--- a/go.mod
+++ b/go.mod
@@ -3,9 +3,7 @@ module github.com/fujiwara/ridge
 go 1.13
 
 require (
-	github.com/apex/go-apex v1.0.0
 	github.com/aws/aws-lambda-go v1.20.0
 	github.com/pires/go-proxyproto v0.1.3
 	github.com/pkg/errors v0.8.1
-	github.com/tj/assert v0.0.0-20190920132354-ee03d75cd160 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,4 @@
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/apex/go-apex v1.0.0 h1:Em8+vo4WXEQp7GfNDTr35HRnE5sFYcRpkTODpVjU39A=
-github.com/apex/go-apex v1.0.0/go.mod h1:Hy8WsL4dnQc/bYBxElRQ7xHXLNBAqz0BVxUhHiGwKLA=
 github.com/aws/aws-lambda-go v1.20.0 h1:ZSweJx/Hy9BoIDXKBEh16vbHH0t0dehnF8MKpMiOWc0=
 github.com/aws/aws-lambda-go v1.20.0/go.mod h1:jJmlefzPfGnckuHdXX7/80O3BvUUi12XOkbv4w9SGLU=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
@@ -20,8 +18,6 @@ github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeV
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/tj/assert v0.0.0-20190920132354-ee03d75cd160 h1:NSWpaDaurcAJY7PkL8Xt0PhZE7qpvbZl5ljd8r6U0bI=
-github.com/tj/assert v0.0.0-20190920132354-ee03d75cd160/go.mod h1:mZ9/Rh9oLWpLLDRpvE+3b7gP/C2YyLFYxNmcLnPTMe0=
 github.com/urfave/cli/v2 v2.2.0/go.mod h1:SE9GqnLQmjVa0iPEY0f1w3ygNIYcIJ0OKPMoW2caLfQ=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/logs_test.go
+++ b/logs_test.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	"testing"
 
-	"github.com/apex/go-apex"
+	"github.com/aws/aws-lambda-go/lambda"
 	"github.com/fujiwara/ridge"
 )
 
@@ -42,7 +42,7 @@ func TestDecodeLogStream(t *testing.T) {
 }
 
 func ExampleDecodeLogStream() {
-	apex.HandleFunc(func(event json.RawMessage, ctx *apex.Context) (interface{}, error) {
+	lambda.Start(func(event json.RawMessage) (interface{}, error) {
 		logStream, err := ridge.DecodeLogStream(event)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
Detect a runtime by AWS_EXECUTION_ENV or AWS_LAMBDA_RUNTIME_API.

Drop apex support.