### PR TITLE
Customizable Request Builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,19 @@ result, _ := svc.Invoke(input)
 
 `ridge.ToRequestV2(*http.Request)` converts a net/http.Request to an API Gateway V2 event payload.
 
+### Custom request builder
+
+You can use a custom request builder to convert the AWS Lambda invoke payload to net/http.Request.
+
+```go
+r := ridge.New(":8080", "/", mux)
+r.RequestBuilder = func(payload json.RawMessage) (*http.Request, error) {
+    // your custom request builder
+}
+r.Run()
+```
+
+default request builder is `ridge.NewRequest`.
 
 ## LICENSE
 

--- a/ridge.go
+++ b/ridge.go
@@ -166,7 +166,7 @@ func (r *Reige) RunWithContext(ctx context.Context) {
 			r.Mux.ServeHTTP(w, req)
 			return w.Response(), nil
 		}
-		lambda.StartWithContext(ctx, handler)
+		lambda.StartWithOptions(handler, lambda.WithContext(ctx))
 	} else {
 		m := http.NewServeMux()
 		switch {

--- a/ridge.go
+++ b/ridge.go
@@ -139,9 +139,9 @@ type Ridge struct {
 	RequestBuilder func(json.RawMessage) (*http.Request, error)
 }
 
-// New creates a new Reige.
-func New(address, prefix string, mux http.Handler) *Reige {
-	return &Reige{
+// New creates a new Ridge.
+func New(address, prefix string, mux http.Handler) *Ridge {
+	return &Ridge{
 		Address:        address,
 		Prefix:         prefix,
 		Mux:            mux,
@@ -150,12 +150,12 @@ func New(address, prefix string, mux http.Handler) *Reige {
 }
 
 // Run runs http handler on AWS Lambda runtime or net/http's server.
-func (r *Reige) Run() {
+func (r *Ridge) Run() {
 	r.RunWithContext(context.Background())
 }
 
 // RunWithContext runs http handler on AWS Lambda runtime or net/http's server with context.
-func (r *Reige) RunWithContext(ctx context.Context) {
+func (r *Ridge) RunWithContext(ctx context.Context) {
 	if strings.HasPrefix(os.Getenv("AWS_EXECUTION_ENV"), "AWS_Lambda") || os.Getenv("AWS_LAMBDA_RUNTIME_API") != "" {
 		// go1.x or custom runtime(provided, provided.al2)
 		handler := func(event json.RawMessage) (interface{}, error) {

--- a/ridge.go
+++ b/ridge.go
@@ -127,33 +127,60 @@ func Run(address, prefix string, mux http.Handler) {
 
 // RunWithContext runs http handler on AWS Lambda runtime or net/http's server with context.
 func RunWithContext(ctx context.Context, address, prefix string, mux http.Handler) {
+	r := New(address, prefix, mux)
+	r.RunWithContext(ctx)
+}
+
+// Ridge is a struct to run http handler on AWS Lambda runtime or net/http's server.
+type Reige struct {
+	Address string
+	Prefix  string
+	Mux     http.Handler
+}
+
+// New creates a new Reige.
+func New(address, prefix string, mux http.Handler) *Reige {
+	return &Reige{
+		Address: address,
+		Prefix:  prefix,
+		Mux:     mux,
+	}
+}
+
+// Run runs http handler on AWS Lambda runtime or net/http's server.
+func (r *Reige) Run() {
+	r.RunWithContext(context.Background())
+}
+
+// RunWithContext runs http handler on AWS Lambda runtime or net/http's server with context.
+func (r *Reige) RunWithContext(ctx context.Context) {
 	if strings.HasPrefix(os.Getenv("AWS_EXECUTION_ENV"), "AWS_Lambda") || os.Getenv("AWS_LAMBDA_RUNTIME_API") != "" {
 		// go1.x or custom runtime(provided, provided.al2)
 		handler := func(event json.RawMessage) (interface{}, error) {
-			r, err := NewRequest(event)
+			req, err := NewRequest(event)
 			if err != nil {
 				log.Println(err)
 				return nil, err
 			}
 			w := NewResponseWriter()
-			mux.ServeHTTP(w, r)
+			r.Mux.ServeHTTP(w, req)
 			return w.Response(), nil
 		}
 		lambda.StartWithContext(ctx, handler)
 	} else {
 		m := http.NewServeMux()
 		switch {
-		case prefix == "/", prefix == "":
-			m.Handle("/", mux)
-		case !strings.HasSuffix(prefix, "/"):
-			m.Handle(prefix+"/", http.StripPrefix(prefix, mux))
+		case r.Prefix == "/", r.Prefix == "":
+			m.Handle("/", r.Mux)
+		case !strings.HasSuffix(r.Prefix, "/"):
+			m.Handle(r.Prefix+"/", http.StripPrefix(r.Prefix, r.Mux))
 		default:
-			m.Handle(prefix, http.StripPrefix(strings.TrimSuffix(prefix, "/"), mux))
+			m.Handle(r.Prefix, http.StripPrefix(strings.TrimSuffix(r.Prefix, "/"), r.Mux))
 		}
-		log.Println("starting up with local httpd", address)
-		listener, err := net.Listen("tcp", address)
+		log.Println("starting up with local httpd", r.Address)
+		listener, err := net.Listen("tcp", r.Address)
 		if err != nil {
-			log.Fatalf("couldn't listen to %s: %s", address, err.Error())
+			log.Fatalf("couldn't listen to %s: %s", r.Address, err.Error())
 		}
 		if ProxyProtocol {
 			log.Println("enables to PROXY protocol")
@@ -165,7 +192,7 @@ func RunWithContext(ctx context.Context, address, prefix string, mux http.Handle
 		go func() {
 			defer wg.Done()
 			<-ctx.Done()
-			log.Println("shutting down local httpd", address)
+			log.Println("shutting down local httpd", r.Address)
 			srv.Shutdown(ctx)
 		}()
 		if err := srv.Serve(listener); err != nil {

--- a/ridge.go
+++ b/ridge.go
@@ -132,7 +132,7 @@ func RunWithContext(ctx context.Context, address, prefix string, mux http.Handle
 }
 
 // Ridge is a struct to run http handler on AWS Lambda runtime or net/http's server.
-type Reige struct {
+type Ridge struct {
 	Address        string
 	Prefix         string
 	Mux            http.Handler


### PR DESCRIPTION
This PR introduces the Reige structure and provides a member called RequestBuidler, giving users more room to intervene in how to convert AWS Lambda payloads to net/http.Request.

One expected use case is a call from the EventBridge Scheduler. I think it would be a good idea to use the following code.

```go
package main

import (
	"fmt"
	"net/http"

	"github.com/fujiwara/ridge"
)

func main() {
	var mux = http.NewServeMux()
	mux.HandleFunc("/", handleRoot)
	mux.HandleFunc("/hello", handleHello)
	r := ridge.New(":8080", "/", mux)
        r.RequestBuilder = func(payload json.RawMessage) (*http.Request, error) {
                req, err := ridge.NewRequest(paylaod)
                if err == nil && req.Method != "" && req.URL != nil && req.URL.Path != "" {
                        return req, nil
                } 
                req = &http.Request{
                        Method: http.MethodPost,
                        URL: &url.URL{
                                Path: "/hello",
                        },
                        Body: io.NopCloser(bytes.NewReader(payload)),
               }
                return req, nil
        }
        r.Run()
}

func handleHello(w http.ResponseWriter, r *http.Request) {
	w.Header().Set("Content-Type", "text/plain")
	fmt.Fprintf(w, "Hello %s\n", r.FormValue("name"))
}

func handleRoot(w http.ResponseWriter, r *http.Request) {
	w.Header().Set("Content-Type", "text/plain")
	fmt.Fprintln(w, "Hello World")
	fmt.Fprintln(w, r.URL)
}