### PR TITLE
Set ridge.StreamingResponse from environment variable RIDGE_STREAMING_RESPONSE

### DIFF
--- a/ridge.go
+++ b/ridge.go
@@ -236,13 +236,13 @@ func RunWithContext(ctx context.Context, address, prefix string, mux http.Handle
 
 // Ridge is a struct to run http handler on AWS Lambda runtime or net/http's server.
 type Ridge struct {
-	Address          string
-	Prefix           string
-	Mux              http.Handler
-	RequestBuilder   func(json.RawMessage) (*http.Request, error)
-	TermHandler      func()
-	ProxyProtocol    bool
-	StramingResponse bool
+	Address           string
+	Prefix            string
+	Mux               http.Handler
+	RequestBuilder    func(json.RawMessage) (*http.Request, error)
+	TermHandler       func()
+	ProxyProtocol     bool
+	StreamingResponse bool
 }
 
 // New creates a new Ridge.
@@ -313,12 +313,11 @@ func (r *Ridge) runAsLambdaHandler(ctx context.Context) {
 			req.Header.Set("Lambda-Runtime-Aws-Request-Id", lc.AwsRequestID)
 			req.Header.Set("Lambda-Runtime-Invoked-Function-Arn", lc.InvokedFunctionArn)
 		}
-		if !r.StramingResponse {
+		if !r.StreamingResponse {
 			w := NewResponseWriter()
 			r.mountMux().ServeHTTP(w, req.WithContext(ctx))
 			return w.Response(), nil
 		}
-		req.Header.Set("Lambda-Runtime-Function-Response-Mode", "streaming")
 		w := NewStreamingResponseWriter()
 		go func() {
 			defer w.Close()


### PR DESCRIPTION
This pull request introduces enhancements and fixes to the `ridge.go` file, focusing on enabling a new streaming response mode, fixing a typo, and improving configurability. The most important changes include adding support for enabling streaming responses via an environment variable, fixing a spelling error in the `Ridge` struct, and updating the logic for handling streaming responses.

### Enhancements to Streaming Response Mode:
* Introduced a new method `setStreamingResponse` in the `Ridge` struct to enable the `StreamingResponse` feature based on the `RIDGE_STREAMING_RESPONSE` environment variable. This includes parsing the variable as a boolean and logging appropriate messages. (`ridge.go`, [ridge.goR269-R291](diffhunk://#diff-70ff38becc17d382d782c93932e70b8d403a68752bf3919837d20e2719475d97R269-R291))
* Updated the `runAsLambdaHandler` method to check the corrected `StreamingResponse` field and removed the hardcoded header for response mode. (`ridge.go`, [ridge.goL316-L321](diffhunk://#diff-70ff38becc17d382d782c93932e70b8d403a68752bf3919837d20e2719475d97L316-L321))

### Bug Fixes:
* Corrected a typo in the `Ridge` struct field name from `StramingResponse` to `StreamingResponse`. (`ridge.go`, [ridge.goL245-R252](diffhunk://#diff-70ff38becc17d382d782c93932e70b8d403a68752bf3919837d20e2719475d97L245-R252))

### Additional Changes:
* Added a new constant `StreamingResponseEnv` to define the environment variable name (`RIDGE_STREAMING_RESPONSE`). (`ridge.go`, [ridge.goL245-R252](diffhunk://#diff-70ff38becc17d382d782c93932e70b8d403a68752bf3919837d20e2719475d97L245-R252))
* Imported the `strconv` package to support parsing the environment variable. (`ridge.go`, [ridge.goR15](diffhunk://#diff-70ff38becc17d382d782c93932e70b8d403a68752bf3919837d20e2719475d97R15))