### PR TITLE
refactor: use payload version header instead of APIType enum

### DIFF
--- a/request_rest_test.go
+++ b/request_rest_test.go
@@ -46,6 +46,11 @@ func TestRESTAPIRequestProcessing(t *testing.T) {
 	if req.Header.Get("X-Amzn-RequestId") != "817175b9-890f-11e6-960e-4f321627a748" {
 		t.Errorf("expected request ID header, got %s", req.Header.Get("X-Amzn-RequestId"))
 	}
+
+	// Verify that REST API has no version header
+	if req.Header.Get(ridge.PayloadVersionHeaderName) != "" {
+		t.Errorf("REST API should not have version header, got %s", req.Header.Get(ridge.PayloadVersionHeaderName))
+	}
 }
 
 func TestPayloadVersionForced(t *testing.T) {

--- a/request_v1_test.go
+++ b/request_v1_test.go
@@ -54,6 +54,10 @@ func TestGetRequest(t *testing.T) {
 	if v := r.Header.Get("X-Amzn-RequestId"); v != "817175b9-890f-11e6-960e-4f321627a748" {
 		t.Errorf("Header[X-Amzn-RequestId]: %s is not expected", v)
 	}
+	// Verify version header is set for v1.0
+	if v := r.Header.Get(ridge.PayloadVersionHeaderName); v != "1.0" {
+		t.Errorf("expected version header 1.0, got %s", v)
+	}
 	if r.RemoteAddr != "203.0.113.1" {
 		t.Errorf("RemoteAddr: %s is not expected", r.RemoteAddr)
 	}
@@ -142,7 +146,7 @@ func TestBase64EncodedRequest(t *testing.T) {
 }
 
 func TestResponseWriter(t *testing.T) {
-	w := ridge.NewResponseWriter(ridge.APITypeHTTP)
+	w := ridge.NewResponseWriter()
 
 	for _, s := range []string{"abcd", "efgh"} {
 		n, err := io.WriteString(w, s)
@@ -194,7 +198,7 @@ func TestResponseWriter__Image(t *testing.T) {
 	}
 	expectedBody := base64.StdEncoding.EncodeToString(bs)
 
-	w := ridge.NewResponseWriter(ridge.APITypeHTTP)
+	w := ridge.NewResponseWriter()
 	req, err := http.NewRequest(http.MethodGet, "http://example.com/bluebox.png", nil)
 	if err != nil {
 		t.Error(err)
@@ -257,6 +261,9 @@ func TestV1RoundTrip(t *testing.T) {
 				t.Error("failed to decode RequestV1", err)
 			}
 
+			// Remove X-Ridge-Payload-Version header before comparison
+			// as it's added by ridge for internal use
+			rr.Header.Del(ridge.PayloadVersionHeaderName)
 			rd, _ := httputil.DumpRequest(rr, true)
 			t.Logf("original request: %s", od)
 			t.Logf("decoded request: %s", rd)

--- a/request_v2_test.go
+++ b/request_v2_test.go
@@ -51,6 +51,10 @@ func TestGetRequestV2(t *testing.T) {
 	if r.RemoteAddr != "203.0.113.1" {
 		t.Errorf("RemoteAddr: %s is not expected", r.RemoteAddr)
 	}
+	// Verify version header is set for v2.0
+	if v := r.Header.Get(ridge.PayloadVersionHeaderName); v != "2.0" {
+		t.Errorf("expected version header 2.0, got %s", v)
+	}
 }
 
 func TestPostRequestV2(t *testing.T) {
@@ -114,6 +118,9 @@ func TestV2RoundTrip(t *testing.T) {
 				t.Error("failed to decode RequestV1", err)
 			}
 
+			// Remove X-Ridge-Payload-Version header before comparison
+			// as it's added by ridge for internal use
+			rr.Header.Del(ridge.PayloadVersionHeaderName)
 			rd, _ := httputil.DumpRequest(rr, true)
 			t.Logf("original request: %s", od)
 			t.Logf("decoded request: %s", rd)

--- a/response_test.go
+++ b/response_test.go
@@ -32,7 +32,7 @@ func TestResponse(t *testing.T) {
 			if err := json.Unmarshal(c.JSON, &res); err != nil {
 				t.Error(err)
 			}
-			w := ridge.NewResponseWriter(ridge.APITypeHTTP)
+			w := ridge.NewResponseWriter()
 			if n, err := res.WriteTo(w); err != nil {
 				t.Error(err)
 			} else if n != 9 {


### PR DESCRIPTION
- Add X-Lambda-Payload-Version header to track event payload version
- Remove APIType enum and detectAPIType function
- Add ResponseFor(version) method to ResponseWriter
- Maintain backward compatibility with Response() method
- Fix tests to work with new implementation

This approach leverages existing version detection in NewRequest() and avoids duplicate JSON parsing while keeping the API simple.

🤖 Generated with [Claude Code](https://claude.ai/code)